### PR TITLE
Add nightly verification workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,87 @@
+name: Nightly
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/nightly.yml'
+  push:
+    paths:
+      - '.github/workflows/nightly.yml'
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'jetbrains'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run formatting, unit tests, and integration tests
+        run: ./gradlew spotlessCheck test integrationTest --no-daemon
+
+      - name: Report scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const title = 'Nightly workflow failure'
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`
+            const body = [
+              'The nightly workflow failed.',
+              '',
+              `- Workflow: ${context.workflow}`,
+              `- Run: ${runUrl}`,
+              `- Commit: ${context.sha}`,
+              `- Ref: ${context.ref}`,
+            ].join('\n')
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            })
+
+            const existing = issues.find((issue) => issue.title === title)
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              })
+              core.info(`Added failure comment to issue #${existing.number}`)
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+              })
+              core.info(`Created issue #${created.data.number}`)
+            }


### PR DESCRIPTION
## Summary
Add a nightly GitHub Actions workflow that runs formatting, unit tests, and the CLI integration test suite.

## What it runs
- `./gradlew spotlessCheck`
- `./gradlew test`
- `./gradlew integrationTest`

## Triggers
- nightly schedule
- manual `workflow_dispatch`

## Related
- Existing release workflow issue: #4