### PR TITLE
Add Windows CLI verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17.0.14+1367.22'
+          java-version: '17'
           distribution: 'jetbrains'
           token: ${{ github.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '17.0.14+1367.22'
           distribution: 'jetbrains'
           token: ${{ github.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,7 @@ on:
 
 jobs:
   verify-generated-project:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            gradle_command: ./gradlew
-          - os: windows-latest
-            gradle_command: .\gradlew.bat
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -37,4 +29,4 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Run formatting and tests
-        run: ${{ matrix.gradle_command }} spotlessCheck test integrationTest --no-daemon
+        run: ./gradlew spotlessCheck test integrationTest --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,15 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            gradle_command: ./gradlew
+          - os: windows-latest
+            gradle_command: .\gradlew.bat
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -28,4 +36,4 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Run formatting and tests
-        run: ./gradlew spotlessCheck test --no-daemon
+        run: ${{ matrix.gradle_command }} spotlessCheck test integrationTest --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify:
+  verify-generated-project:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ github.token }}
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ github.token }}
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ permissions:
   issues: write
 
 jobs:
-  verify:
+  verify-generated-project:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,6 @@
 name: Nightly
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/nightly.yml'
   push:
     paths:
       - '.github/workflows/nightly.yml'
@@ -35,7 +32,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17.0.14+1367.22'
+          java-version: '17'
           distribution: 'jetbrains'
           token: ${{ github.token }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '17.0.14+1367.22'
           distribution: 'jetbrains'
           token: ${{ github.token }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,17 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            gradle_command: ./gradlew
+          - os: macos-latest
+            gradle_command: ./gradlew
+          - os: windows-latest
+            gradle_command: .\gradlew.bat
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +49,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Run formatting, unit tests, and integration tests
-        run: ./gradlew spotlessCheck test integrationTest --no-daemon
+        run: ${{ matrix.gradle_command }} spotlessCheck test integrationTest --no-daemon
 
       - name: Report scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -47,7 +47,7 @@ class CliIntegrationTest {
             assertThat(initResult.output).contains("Success! Your new Compose app is ready")
 
             val compileResult = runProcess(
-                command = listOf("./gradlew", ":composeApp:compileKotlinJvm"),
+                command = listOf(projectGradleScript(), ":composeApp:compileKotlinJvm"),
                 workingDir = projectDir,
                 timeoutSeconds = 180,
             )
@@ -73,13 +73,19 @@ class CliIntegrationTest {
         return jar
     }
 
+    private fun projectGradleScript(): String = if (System.getProperty("os.name").startsWith("Windows")) {
+        "gradlew.bat"
+    } else {
+        "./gradlew"
+    }
+
     private fun runProcess(
         command: List<String>,
         workingDir: File,
         stdin: String = "",
         timeoutSeconds: Long,
     ): ProcessResult {
-        val process = ProcessBuilder(command)
+        val process = ProcessBuilder(platformCommand(command))
             .directory(workingDir)
             .redirectErrorStream(true)
             .start()
@@ -111,6 +117,16 @@ class CliIntegrationTest {
             exitCode = if (finished) process.exitValue() else -1,
             output = output.toString(),
         )
+    }
+
+    private fun platformCommand(command: List<String>): List<String> {
+        val executable = command.firstOrNull() ?: return command
+        val isWindows = System.getProperty("os.name").startsWith("Windows")
+        return if (isWindows && (executable.endsWith(".bat") || executable.endsWith(".cmd"))) {
+            listOf("cmd.exe", "/c") + command
+        } else {
+            command
+        }
     }
 
     private data class ProcessResult(

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -19,6 +19,8 @@ val JVM = "jvm"
 val IOS = "ios"
 val WEB = "web"
 
+private fun File.toResourcePath(): String = invariantSeparatorsPath.replace('\\', '/')
+
 suspend fun main(args: Array<String>) {
     ComposablesCli()
         .subcommands(Init(), Target())
@@ -874,7 +876,7 @@ fun DefaultPreview() {
                         dir.walkTopDown().forEach { file ->
                             if (file.isFile) {
                                 val relativePath = file.relativeTo(dir)
-                                resources.add("$path/${relativePath.path}")
+                                resources.add("$path/${relativePath.toResourcePath()}")
                             }
                         }
                     }
@@ -1414,7 +1416,7 @@ fun WebAppPreview() {
                         dir.walkTopDown().forEach { file ->
                             if (file.isFile) {
                                 val relativePath = file.relativeTo(dir)
-                                resources.add("$path/${relativePath.path}")
+                                resources.add("$path/${relativePath.toResourcePath()}")
                             }
                         }
                     }
@@ -1472,7 +1474,7 @@ fun WebAppPreview() {
                         dir.walkTopDown().forEach { file ->
                             if (file.isFile) {
                                 val relativePath = file.relativeTo(dir)
-                                resources.add("$path/${relativePath.path}")
+                                resources.add("$path/${relativePath.toResourcePath()}")
                             }
                         }
                     }
@@ -1544,7 +1546,7 @@ fun WebAppPreview() {
                         dir.walkTopDown().forEach { file ->
                             if (file.isFile) {
                                 val relativePath = file.relativeTo(dir)
-                                resources.add("$path/${relativePath.path}")
+                                resources.add("$path/${relativePath.toResourcePath()}")
                             }
                         }
                     }
@@ -1708,7 +1710,7 @@ private fun cloneGradleProjectAt(
                     dir.walkTopDown().forEach { file ->
                         if (file.isFile) { // Only include files, not directories
                             val relativePath = file.relativeTo(dir)
-                            resources.add("$path/${relativePath.path}")
+                            resources.add("$path/${relativePath.toResourcePath()}")
                         }
                     }
                 }
@@ -2421,7 +2423,7 @@ fun createModuleOnly(
                     dir.walkTopDown().forEach { file ->
                         if (file.isFile) {
                             val relativePath = file.relativeTo(dir)
-                            resources.add("$path/${relativePath.path}")
+                            resources.add("$path/${relativePath.toResourcePath()}")
                         }
                     }
                 }
@@ -2739,7 +2741,7 @@ private fun createIosAppDirectory(
                     dir.walkTopDown().forEach { file ->
                         if (file.isFile) {
                             val relativePath = file.relativeTo(dir)
-                            resources.add("$path/${relativePath.path}")
+                            resources.add("$path/${relativePath.toResourcePath()}")
                         }
                     }
                 }

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -2817,7 +2817,7 @@ private fun getKotlinVersion(projectDir: File): String? {
         }
 
         // Try to run gradle and get the version
-        val process = ProcessBuilder("./gradlew", "properties", "-q", "--no-daemon")
+        val process = ProcessBuilder(gradleScript, "properties", "-q", "--no-daemon")
             .directory(projectDir)
             .redirectErrorStream(true)
             .start()

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -75,12 +75,14 @@ class CliTest {
 
     @Test
     fun `init derives project name from absolute directory path`() {
+        val workingDir = File("workspace").absolutePath
+        val projectPath = File("sample-app").absolutePath
         val targetDir = resolveTargetDirectory(
-            workingDir = "/Users/alexstyl/projects/composables-cli",
-            projectPath = "/Users/alexstyl/projects/sample-app",
+            workingDir = workingDir,
+            projectPath = projectPath,
         )
 
-        assertThat(targetDir.absolutePath).isEqualTo("/Users/alexstyl/projects/sample-app")
+        assertThat(targetDir.absolutePath).isEqualTo(projectPath)
         assertThat(targetDir.name).isEqualTo("sample-app")
     }
 

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -139,12 +139,36 @@ class CliTest {
         }
     }
 
+    @Test
+    fun `gradleScript uses batch file on windows`() {
+        withOsName("Windows 11") {
+            assertThat(gradleScript).isEqualTo("gradlew.bat")
+        }
+    }
+
+    @Test
+    fun `gradleScript uses shell script on unix`() {
+        withOsName("Linux") {
+            assertThat(gradleScript).isEqualTo("./gradlew")
+        }
+    }
+
     private fun withTempDir(block: (File) -> Unit) {
         val dir = Files.createTempDirectory("composables-cli-test").toFile()
         try {
             block(dir)
         } finally {
             dir.deleteRecursively()
+        }
+    }
+
+    private fun withOsName(value: String, block: () -> Unit) {
+        val original = System.getProperty("os.name")
+        try {
+            System.setProperty("os.name", value)
+            block()
+        } finally {
+            System.setProperty("os.name", original)
         }
     }
 


### PR DESCRIPTION
## Summary
- route Gradle wrapper execution through the existing OS-aware selector
- add unit coverage for Windows vs Unix wrapper selection
- expand CI to run `spotlessCheck`, `test`, and `integrationTest` on both Ubuntu and Windows

## Verification
- `./gradlew :cli:test --tests com.composables.cli.CliTest --console=plain`
- `./gradlew spotlessCheck :cli:integrationTest --console=plain`