### PR TITLE
Add npm distribution lane

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -48,6 +53,9 @@ jobs:
 
       - name: Run formatting, unit tests, and integration tests
         run: ${{ matrix.gradle_command }} spotlessCheck test integrationTest --no-daemon
+
+      - name: Check npm package
+        run: ${{ matrix.gradle_command }} npmPackageCheck --no-daemon
 
       - name: Report scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -74,6 +74,13 @@ jobs:
           java-version: '17'
           distribution: 'jetbrains'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@composablehorizons'
+
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -84,8 +91,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Lint, Test, and Build Shadow JAR
-        run: ./gradlew spotlessCheck test shadowJar --no-daemon
+      - name: Run product checks
+        run: ./gradlew spotlessCheck test integrationTest --no-daemon
+
+      - name: Check npm package
+        run: ./gradlew npmPackageCheck --no-daemon
+
+      - name: Publish npm package
+        run: npm publish cli/build/npm/package --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   prepare:
@@ -75,11 +76,11 @@ jobs:
           distribution: 'jetbrains'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@composablehorizons'
+          package-manager-cache: false
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
@@ -99,8 +100,6 @@ jobs:
 
       - name: Publish npm package
         run: npm publish cli/build/npm/package --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -136,6 +136,7 @@ val assembleNpmPackage = tasks.register<Sync>("assembleNpmPackage") {
             expand("version" to project.version.toString())
         }
     }
+    from(rootProject.file("README.md"))
     from(tasks.named<ShadowJar>("shadowJar")) {
         rename { "composables.jar" }
     }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -3,6 +3,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
+import java.nio.charset.StandardCharsets
 
 plugins {
     application
@@ -55,12 +56,21 @@ sourceSets {
         compileClasspath += sourceSets.main.get().output + configurations.testRuntimeClasspath.get()
         runtimeClasspath += output + compileClasspath
     }
+    create("npmTest") {
+        java.setSrcDirs(listOf("src/npmTest/kotlin"))
+        resources.setSrcDirs(emptyList<String>())
+        compileClasspath += sourceSets.main.get().output + configurations.testRuntimeClasspath.get()
+        runtimeClasspath += output + compileClasspath
+    }
 }
 
 val integrationTestSourceSet = sourceSets.named("integrationTest").get()
+val npmTestSourceSet = sourceSets.named("npmTest").get()
 
 configurations[integrationTestSourceSet.implementationConfigurationName].extendsFrom(configurations.testImplementation.get())
 configurations[integrationTestSourceSet.runtimeOnlyConfigurationName].extendsFrom(configurations.testRuntimeOnly.get())
+configurations[npmTestSourceSet.implementationConfigurationName].extendsFrom(configurations.testImplementation.get())
+configurations[npmTestSourceSet.runtimeOnlyConfigurationName].extendsFrom(configurations.testRuntimeOnly.get())
 
 dependencies {
     implementation("com.alexstyl:debugln:1.0.3")
@@ -86,6 +96,17 @@ val integrationTest = tasks.register<Test>("integrationTest") {
     useJUnitPlatform()
 }
 
+val npmPackageCheck = tasks.register<Test>("npmPackageCheck") {
+    description = "Verifies the published npm package installs and launches correctly."
+    group = "verification"
+
+    testClassesDirs = npmTestSourceSet.output.classesDirs
+    classpath = npmTestSourceSet.runtimeClasspath
+    shouldRunAfter(tasks.named("integrationTest"))
+    dependsOn(tasks.named("npmPack"))
+    useJUnitPlatform()
+}
+
 tasks.named<ShadowJar>("shadowJar") {
     group = "build"
     from(sourceSets.main.get().output)
@@ -97,6 +118,41 @@ tasks.named<ShadowJar>("shadowJar") {
         attributes("Main-Class" to mainClassName)
     }
     mergeServiceFiles()
+}
+
+val npmPackageDir = layout.buildDirectory.dir("npm/package")
+val npmTarballDir = layout.buildDirectory.dir("npm/tarball")
+
+val assembleNpmPackage = tasks.register<Sync>("assembleNpmPackage") {
+    description = "Assembles the npm package for Composables CLI."
+    group = "distribution"
+
+    dependsOn(tasks.named("shadowJar"))
+
+    from("src/npm") {
+        includeEmptyDirs = false
+        filteringCharset = StandardCharsets.UTF_8.name()
+        filesMatching("package.json") {
+            expand("version" to project.version.toString())
+        }
+    }
+    from(tasks.named<ShadowJar>("shadowJar")) {
+        rename { "composables.jar" }
+    }
+    into(npmPackageDir)
+}
+
+val npmPack = tasks.register<Exec>("npmPack") {
+    description = "Creates a tarball for the npm package."
+    group = "distribution"
+
+    dependsOn(assembleNpmPackage)
+
+    inputs.dir(npmPackageDir)
+    outputs.dir(npmTarballDir)
+
+    workingDir(npmPackageDir)
+    commandLine(npmCommand(), "pack", "--pack-destination", npmTarballDir.get().asFile.absolutePath)
 }
 
 tasks.jar {
@@ -129,3 +185,5 @@ tasks.register<Exec>("runTemplate") {
     workingDir(renderedProjectDir)
     commandLine("./gradlew", "run")
 }
+
+fun npmCommand(): String = if (System.getProperty("os.name").startsWith("Windows")) "npm.cmd" else "npm"

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -153,6 +153,10 @@ val npmPack = tasks.register<Exec>("npmPack") {
     outputs.dir(npmTarballDir)
 
     workingDir(npmPackageDir)
+    doFirst {
+        delete(npmTarballDir)
+        npmTarballDir.get().asFile.mkdirs()
+    }
     commandLine(npmCommand(), "pack", "--pack-destination", npmTarballDir.get().asFile.absolutePath)
 }
 

--- a/cli/src/npm/bin/composables.js
+++ b/cli/src/npm/bin/composables.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const packageRoot = path.resolve(__dirname, "..");
+const jarPath = path.join(packageRoot, "composables.jar");
+
+if (!fs.existsSync(jarPath)) {
+    console.error(`Composables CLI jar not found at ${jarPath}`);
+    process.exit(1);
+}
+
+const result = spawnSync("java", ["-jar", jarPath, ...process.argv.slice(2)], {
+    stdio: "inherit",
+});
+
+if (result.error) {
+    if (result.error.code === "ENOENT") {
+        console.error("Java 17 or newer is required to run Composables CLI.");
+        console.error("Install Java and try again.");
+    } else {
+        console.error(result.error.message);
+    }
+    process.exit(1);
+}
+
+if (typeof result.status === "number") {
+    process.exit(result.status);
+}
+
+process.exit(1);

--- a/cli/src/npm/package.json
+++ b/cli/src/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@composablehorizons/composables",
+  "name": "composables-cli",
   "version": "${version}",
   "description": "Composables CLI",
   "license": "MIT",

--- a/cli/src/npm/package.json
+++ b/cli/src/npm/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@composablehorizons/composables",
+  "version": "{{version}}",
+  "description": "Composables CLI",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/composablehorizons/composables-cli.git"
+  },
+  "homepage": "https://github.com/composablehorizons/composables-cli",
+  "bugs": {
+    "url": "https://github.com/composablehorizons/composables-cli/issues"
+  },
+  "bin": {
+    "composables": "./bin/composables.js"
+  },
+  "files": [
+    "bin",
+    "composables.jar"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "compose",
+    "jetbrains-compose",
+    "kotlin",
+    "cli"
+  ]
+}

--- a/cli/src/npm/package.json
+++ b/cli/src/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@composablehorizons/composables",
-  "version": "{{version}}",
+  "version": "${version}",
   "description": "Composables CLI",
   "license": "MIT",
   "repository": {

--- a/cli/src/npmTest/kotlin/com/composables/cli/NpmPackageIntegrationTest.kt
+++ b/cli/src/npmTest/kotlin/com/composables/cli/NpmPackageIntegrationTest.kt
@@ -1,0 +1,109 @@
+package com.composables.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+class NpmPackageIntegrationTest {
+
+    @Test
+    fun `published npm package installs and runs`() {
+        val rootDir = Files.createTempDirectory("composables-cli-npm").toFile()
+        try {
+            val tarball = npmPackageTarball()
+
+            val installResult = runProcess(
+                command = listOf(npmExecutable(), "install", tarball.absolutePath),
+                workingDir = rootDir,
+                timeoutSeconds = 120,
+            )
+
+            assertThat(installResult.finished).isTrue()
+            assertThat(installResult.exitCode).isEqualTo(0)
+            assertThat(installResult.output).contains("added")
+
+            val versionResult = runProcess(
+                command = listOf(npmInstalledLauncher(rootDir).absolutePath, "--version"),
+                workingDir = rootDir,
+                timeoutSeconds = 60,
+            )
+
+            assertThat(versionResult.finished).isTrue()
+            assertThat(versionResult.exitCode).isEqualTo(0)
+            assertThat(Regex("""\d+\.\d+\.\d+""").matches(versionResult.output.trim())).isTrue()
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    private fun npmPackageTarball(): File {
+        val tarballDir = File("build/npm/tarball")
+        val tarballs = tarballDir.listFiles { file -> file.extension == "tgz" }.orEmpty()
+        check(tarballs.size == 1) {
+            "Expected exactly one npm tarball in ${tarballDir.absolutePath}, found ${tarballs.joinToString { it.name }}"
+        }
+        return tarballs.single()
+    }
+
+    private fun npmInstalledLauncher(rootDir: File): File {
+        val launcherName = if (System.getProperty("os.name").startsWith("Windows")) "composables.cmd" else "composables"
+        val launcher = File(rootDir, "node_modules/.bin/$launcherName")
+        check(launcher.isFile) { "Expected npm launcher at ${launcher.absolutePath}" }
+        return launcher
+    }
+
+    private fun npmExecutable(): String = if (System.getProperty("os.name").startsWith("Windows")) "npm.cmd" else "npm"
+
+    private fun runProcess(
+        command: List<String>,
+        workingDir: File,
+        timeoutSeconds: Long,
+    ): ProcessResult {
+        val process = ProcessBuilder(platformCommand(command))
+            .directory(workingDir)
+            .redirectErrorStream(true)
+            .start()
+
+        val output = StringBuilder()
+        val readerThread = Thread {
+            process.inputStream.bufferedReader().useLines { lines ->
+                lines.forEach { line ->
+                    output.appendLine(line)
+                }
+            }
+        }.apply { start() }
+
+        val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+        if (!finished) {
+            process.destroyForcibly()
+        }
+        readerThread.join()
+
+        return ProcessResult(
+            finished = finished,
+            exitCode = if (finished) process.exitValue() else -1,
+            output = output.toString(),
+        )
+    }
+
+    private fun platformCommand(command: List<String>): List<String> {
+        val executable = command.firstOrNull() ?: return command
+        val isWindows = System.getProperty("os.name").startsWith("Windows")
+        return if (isWindows && (executable.endsWith(".bat") || executable.endsWith(".cmd"))) {
+            listOf("cmd.exe", "/c") + command
+        } else {
+            command
+        }
+    }
+
+    private data class ProcessResult(
+        val finished: Boolean,
+        val exitCode: Int,
+        val output: String,
+    )
+}


### PR DESCRIPTION
## Summary

- add an npm distribution lane that wraps the published `composables.jar` with a cross-platform Node launcher
- keep core CLI integration tests independent from npm packaging
- add `npmPackageCheck` as a separate packaging verification task and run it in nightly and release workflows
- keep GitHub Releases focused on the raw jar while npm becomes a separate install channel

## Validation

- `./gradlew :cli:spotlessCheck :cli:test :cli:integrationTest --no-daemon`
- `./gradlew :cli:npmPackageCheck --no-daemon`

## Notes

- this does not change normal local development flow for the Kotlin CLI
- the npm lane is only for distribution and release verification
