### PR TITLE
Add create-app command

### DIFF
--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -60,6 +60,81 @@ class CliIntegrationTest {
         }
     }
 
+    @Test
+    fun `cli create-app creates a jvm project that compiles`() {
+        val rootDir = Files.createTempDirectory("composables-cli-create-app").toFile()
+        try {
+            val projectDir = File(rootDir, "sample-app")
+            val launcher = installedLauncher()
+
+            val createResult = runProcess(
+                command = listOf(
+                    launcher.absolutePath,
+                    "create-app",
+                    projectDir.absolutePath,
+                    "--package",
+                    "com.example.sampleapp",
+                    "--app-name",
+                    "Sample App",
+                    "--targets",
+                    "jvm",
+                ),
+                workingDir = rootDir,
+                timeoutSeconds = 60,
+            )
+
+            assertThat(createResult.finished).isTrue()
+            assertThat(createResult.exitCode).isEqualTo(0)
+            assertThat(createResult.output).contains("Success! Your new Compose app is ready")
+
+            val compileResult = runProcess(
+                command = listOf(projectGradleScript(), ":composeApp:compileKotlinJvm"),
+                workingDir = projectDir,
+                timeoutSeconds = 180,
+            )
+
+            assertThat(compileResult.finished).isTrue()
+            assertThat(compileResult.exitCode).isEqualTo(0)
+            assertThat(compileResult.output).contains("BUILD SUCCESSFUL")
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `cli create-app requires overwrite for non-empty directories`() {
+        val rootDir = Files.createTempDirectory("composables-cli-create-app-existing").toFile()
+        try {
+            val projectDir = File(rootDir, "sample-app").apply {
+                mkdirs()
+                File(this, "keep.txt").writeText("existing")
+            }
+            val launcher = installedLauncher()
+
+            val createResult = runProcess(
+                command = listOf(
+                    launcher.absolutePath,
+                    "create-app",
+                    projectDir.absolutePath,
+                    "--package",
+                    "com.example.sampleapp",
+                    "--app-name",
+                    "Sample App",
+                    "--targets",
+                    "jvm",
+                ),
+                workingDir = rootDir,
+                timeoutSeconds = 60,
+            )
+
+            assertThat(createResult.finished).isTrue()
+            assertThat(createResult.exitCode).isEqualTo(1)
+            assertThat(createResult.output).contains("already exists and is not empty")
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
     private fun installedLauncher(): File {
         val scriptName = if (System.getProperty("os.name").startsWith("Windows")) "composables.bat" else "composables"
         val launcher = File("build/install/composables/bin/$scriptName")

--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -134,6 +134,27 @@ class CliIntegrationTest {
     }
 
     @Test
+    fun `cli create-app with no args fails cleanly without stdin`() {
+        val rootDir = Files.createTempDirectory("composables-cli-create-app-no-stdin").toFile()
+        try {
+            val launcher = installedLauncher()
+
+            val createResult = runProcess(
+                command = listOf(launcher.absolutePath, "create-app"),
+                workingDir = rootDir,
+                timeoutSeconds = 60,
+            )
+
+            assertThat(createResult.finished).isTrue()
+            assertThat(createResult.exitCode).isEqualTo(1)
+            assertThat(createResult.output).contains("Interactive mode requires stdin")
+            assertThat(createResult.output).doesNotContain("ReadAfterEOFException")
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `cli create-app requires overwrite for non-empty directories`() {
         val rootDir = Files.createTempDirectory("composables-cli-create-app-existing").toFile()
         try {

--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -102,6 +102,38 @@ class CliIntegrationTest {
     }
 
     @Test
+    fun `cli create-app with no args runs interactively and creates a jvm project that compiles`() {
+        val rootDir = Files.createTempDirectory("composables-cli-create-app-interactive").toFile()
+        try {
+            val projectDir = File(rootDir, "sample-app")
+            val launcher = installedLauncher()
+
+            val createResult = runProcess(
+                command = listOf(launcher.absolutePath, "create-app"),
+                workingDir = rootDir,
+                stdin = "sample-app\ncom.example.sampleapp\nSample App\nn\ny\nn\nn\n",
+                timeoutSeconds = 60,
+            )
+
+            assertThat(createResult.finished).isTrue()
+            assertThat(createResult.exitCode).isEqualTo(0)
+            assertThat(createResult.output).contains("Success! Your new Compose app is ready")
+
+            val compileResult = runProcess(
+                command = listOf(projectGradleScript(), ":composeApp:compileKotlinJvm"),
+                workingDir = projectDir,
+                timeoutSeconds = 180,
+            )
+
+            assertThat(compileResult.finished).isTrue()
+            assertThat(compileResult.exitCode).isEqualTo(0)
+            assertThat(compileResult.output).contains("BUILD SUCCESSFUL")
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `cli create-app requires overwrite for non-empty directories`() {
         val rootDir = Files.createTempDirectory("composables-cli-create-app-existing").toFile()
         try {
@@ -130,6 +162,34 @@ class CliIntegrationTest {
             assertThat(createResult.finished).isTrue()
             assertThat(createResult.exitCode).isEqualTo(1)
             assertThat(createResult.output).contains("already exists and is not empty")
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `cli create-app with partial args fails without prompting`() {
+        val rootDir = Files.createTempDirectory("composables-cli-create-app-partial").toFile()
+        try {
+            val launcher = installedLauncher()
+
+            val createResult = runProcess(
+                command = listOf(
+                    launcher.absolutePath,
+                    "create-app",
+                    "sample-app",
+                    "--package",
+                    "com.example.sampleapp",
+                ),
+                workingDir = rootDir,
+                timeoutSeconds = 60,
+            )
+
+            assertThat(createResult.finished).isTrue()
+            assertThat(createResult.exitCode).isEqualTo(1)
+            assertThat(createResult.output).contains("When using create-app non-interactively")
+            assertThat(createResult.output).contains("--app-name")
+            assertThat(createResult.output).contains("--targets")
         } finally {
             rootDir.deleteRecursively()
         }

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -69,10 +69,19 @@ class CreateApp : CliktCommand("create-app") {
         val targets: Set<String>
 
         if (!anyExplicitInput) {
-            target = readNewAppDirectory(workingDir)
-            resolvedPackageName = readNamespace()
-            resolvedAppName = readAppName()
-            targets = readTargets()
+            try {
+                target = readNewAppDirectory(workingDir)
+                resolvedPackageName = readNamespace()
+                resolvedAppName = readAppName()
+                targets = readTargets()
+            } catch (error: RuntimeException) {
+                if (error::class.simpleName == "ReadAfterEOFException" || error.message?.contains("EOF has already been reached") == true) {
+                    throw UsageError(
+                        "Interactive mode requires stdin. Pass <directory>, --package, --app-name, and --targets for non-interactive use.",
+                    )
+                }
+                throw error
+            }
         } else {
             val missingInputs = buildList {
                 if (directory == null) add("<directory>")

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -5,10 +5,14 @@ import com.alexstyl.debugln.infoln
 import com.alexstyl.debugln.warnln
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.versionOption
 import java.io.File
 import java.io.InputStream
@@ -23,7 +27,7 @@ private fun File.toResourcePath(): String = invariantSeparatorsPath.replace('\\'
 
 suspend fun main(args: Array<String>) {
     ComposablesCli()
-        .subcommands(Init(), Target())
+        .subcommands(CreateApp(), Init(), Target())
         .main(args)
 }
 
@@ -43,6 +47,66 @@ class ComposablesCli : CliktCommand(name = "composables") {
         If you have any problems or need help, do not hesitate to ask for help at:
             https://github.com/composablehorizons/composables-cli
     """.trimIndent()
+}
+
+class CreateApp : CliktCommand("create-app") {
+    override fun help(context: Context): String = """
+        Creates a new Compose Multiplatform app in the specified <directory> path.
+    """.trimIndent()
+
+    private val directory by argument("directory", help = "The directory path to create the new app in")
+    private val packageName by option("--package", help = "The package name for the generated app").required()
+    private val appName by option("--app-name", help = "The display name for the generated app").required()
+    private val targetsInput by option("--targets", help = "Comma-separated targets: android,jvm,ios,web").required()
+    private val overwrite by option("--overwrite", help = "Overwrite an existing target directory").flag(default = false)
+
+    override fun run() {
+        if (!isValidPackageName(packageName)) {
+            throw UsageError("Invalid package name. Must be a valid Java package name (e.g., com.example.app)")
+        }
+
+        if (!isValidAppName(appName)) {
+            throw UsageError("Invalid app name. Must contain at least one letter or digit")
+        }
+
+        val targets = try {
+            parseTargets(targetsInput)
+        } catch (error: IllegalArgumentException) {
+            throw UsageError(error.message ?: "Invalid targets")
+        }
+        val target = resolveTargetDirectory(
+            workingDir = System.getProperty("user.dir"),
+            projectPath = directory,
+        )
+
+        when {
+            target.exists() && overwrite -> {
+                if (!target.deleteRecursively()) {
+                    throw UsageError("Failed to overwrite existing directory at ${target.absolutePath}")
+                }
+            }
+
+            target.exists() && target.isFile -> {
+                throw UsageError("Target path ${target.absolutePath} is a file. Choose a different directory or use --overwrite.")
+            }
+
+            target.exists() && target.listFiles()?.isNotEmpty() == true -> {
+                throw UsageError("Target directory ${target.absolutePath} already exists and is not empty. Use --overwrite to replace it.")
+            }
+        }
+
+        if (!target.exists() && !target.mkdirs()) {
+            throw UsageError("Failed to create directory at ${target.absolutePath}")
+        }
+
+        cloneGradleProjectAndPrint(
+            target = target,
+            packageName = packageName,
+            appName = appName,
+            targets = targets,
+            moduleName = "composeApp",
+        )
+    }
 }
 
 class Init : CliktCommand("init") {
@@ -234,13 +298,6 @@ class Init : CliktCommand("init") {
         }
     }
 
-    private fun isValidAppName(appName: String): Boolean {
-        if (appName.isEmpty()) return false
-
-        // Check if it contains at least one letter or digit
-        return appName.any { char -> char.isLetterOrDigit() }
-    }
-
     private fun readModuleName(projectName: String): String {
         while (true) {
             echo("Enter module name (default: composeApp): ", trailingNewline = false)
@@ -291,28 +348,6 @@ class Init : CliktCommand("init") {
             return moduleName
         }
     }
-
-    private fun isValidModuleName(moduleName: String): Boolean {
-        if (moduleName.isEmpty()) return false
-
-        // Check if it contains at least one letter or digit
-        return moduleName.any { char -> char.isLetterOrDigit() } &&
-            moduleName.all { char -> char.isLetterOrDigit() || char == '-' || char == '_' }
-    }
-
-    private fun isValidPackageName(packageName: String): Boolean {
-        if (packageName.isEmpty()) return false
-
-        val parts = packageName.split(".")
-        if (parts.size < 2) return false
-
-        // Check each part is a valid Java identifier
-        return parts.all { part ->
-            part.isNotEmpty() &&
-                part[0].isLetter() &&
-                part.all { char -> char.isLetterOrDigit() || char == '_' }
-        }
-    }
 }
 
 internal fun resolveTargetDirectory(workingDir: String, projectPath: String): File {
@@ -325,6 +360,53 @@ internal fun resolveTargetDirectory(workingDir: String, projectPath: String): Fi
         requestedPath
     } else {
         File(workingDir).resolve(projectPath)
+    }
+}
+
+internal fun isValidAppName(appName: String): Boolean {
+    if (appName.isEmpty()) return false
+    return appName.any { char -> char.isLetterOrDigit() }
+}
+
+internal fun isValidModuleName(moduleName: String): Boolean {
+    if (moduleName.isEmpty()) return false
+    return moduleName.any { char -> char.isLetterOrDigit() } &&
+        moduleName.all { char -> char.isLetterOrDigit() || char == '-' || char == '_' }
+}
+
+internal fun isValidPackageName(packageName: String): Boolean {
+    if (packageName.isEmpty()) return false
+
+    val parts = packageName.split(".")
+    if (parts.size < 2) return false
+
+    return parts.all { part ->
+        part.isNotEmpty() &&
+            part[0].isLetter() &&
+            part.all { char -> char.isLetterOrDigit() || char == '_' }
+    }
+}
+
+internal fun parseTargets(targetsInput: String): Set<String> {
+    val validTargets = setOf(ANDROID, JVM, IOS, WEB)
+    val targets = targetsInput
+        .split(",")
+        .map { it.trim().lowercase() }
+        .filter { it.isNotEmpty() }
+
+    if (targets.isEmpty()) {
+        throw IllegalArgumentException("At least one target is required. Use --targets android,jvm,ios,web")
+    }
+
+    val invalidTargets = targets.filterNot { it in validTargets }
+    if (invalidTargets.isNotEmpty()) {
+        throw IllegalArgumentException(
+            "Unknown targets: ${invalidTargets.joinToString(", ")}. Available targets: android, jvm, ios, web",
+        )
+    }
+
+    return linkedSetOf<String>().apply {
+        addAll(targets)
     }
 }
 
@@ -360,7 +442,7 @@ class Target : CliktCommand("target") {
         if (!isValidComposeAppDirectory(workingDir)) {
             echo("This doesn't appear to be a Compose Multiplatform project.")
             echo("To create a new Compose app, run:")
-            echo("    composables init app")
+            echo("    composables create-app app --package com.example.app --app-name \"My App\" --targets android,jvm,ios,web")
             return
         }
 

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -12,7 +12,6 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.versionOption
 import java.io.File
 import java.io.InputStream
@@ -54,45 +53,58 @@ class CreateApp : CliktCommand("create-app") {
         Creates a new Compose Multiplatform app in the specified <directory> path.
     """.trimIndent()
 
-    private val directory by argument("directory", help = "The directory path to create the new app in")
-    private val packageName by option("--package", help = "The package name for the generated app").required()
-    private val appName by option("--app-name", help = "The display name for the generated app").required()
-    private val targetsInput by option("--targets", help = "Comma-separated targets: android,jvm,ios,web").required()
+    private val directory by argument("directory", help = "The directory path to create the new app in").optional()
+    private val packageName by option("--package", help = "The package name for the generated app")
+    private val appName by option("--app-name", help = "The display name for the generated app")
+    private val targetsInput by option("--targets", help = "Comma-separated targets: android,jvm,ios,web")
     private val overwrite by option("--overwrite", help = "Overwrite an existing target directory").flag(default = false)
 
     override fun run() {
-        if (!isValidPackageName(packageName)) {
-            throw UsageError("Invalid package name. Must be a valid Java package name (e.g., com.example.app)")
-        }
+        val anyExplicitInput = directory != null || packageName != null || appName != null || targetsInput != null || overwrite
+        val workingDir = System.getProperty("user.dir")
 
-        if (!isValidAppName(appName)) {
-            throw UsageError("Invalid app name. Must contain at least one letter or digit")
-        }
+        val target: File
+        val resolvedPackageName: String
+        val resolvedAppName: String
+        val targets: Set<String>
 
-        val targets = try {
-            parseTargets(targetsInput)
-        } catch (error: IllegalArgumentException) {
-            throw UsageError(error.message ?: "Invalid targets")
-        }
-        val target = resolveTargetDirectory(
-            workingDir = System.getProperty("user.dir"),
-            projectPath = directory,
-        )
-
-        when {
-            target.exists() && overwrite -> {
-                if (!target.deleteRecursively()) {
-                    throw UsageError("Failed to overwrite existing directory at ${target.absolutePath}")
-                }
+        if (!anyExplicitInput) {
+            target = readNewAppDirectory(workingDir)
+            resolvedPackageName = readNamespace()
+            resolvedAppName = readAppName()
+            targets = readTargets()
+        } else {
+            val missingInputs = buildList {
+                if (directory == null) add("<directory>")
+                if (packageName == null) add("--package")
+                if (appName == null) add("--app-name")
+                if (targetsInput == null) add("--targets")
+            }
+            if (missingInputs.isNotEmpty()) {
+                throw UsageError("When using create-app non-interactively, specify all required inputs. Missing: ${missingInputs.joinToString(", ")}")
             }
 
-            target.exists() && target.isFile -> {
-                throw UsageError("Target path ${target.absolutePath} is a file. Choose a different directory or use --overwrite.")
+            resolvedPackageName = packageName!!
+            resolvedAppName = appName!!
+
+            if (!isValidPackageName(resolvedPackageName)) {
+                throw UsageError("Invalid package name. Must be a valid Java package name (e.g., com.example.app)")
             }
 
-            target.exists() && target.listFiles()?.isNotEmpty() == true -> {
-                throw UsageError("Target directory ${target.absolutePath} already exists and is not empty. Use --overwrite to replace it.")
+            if (!isValidAppName(resolvedAppName)) {
+                throw UsageError("Invalid app name. Must contain at least one letter or digit")
             }
+
+            targets = try {
+                parseTargets(targetsInput!!)
+            } catch (error: IllegalArgumentException) {
+                throw UsageError(error.message ?: "Invalid targets")
+            }
+            target = resolveTargetDirectory(
+                workingDir = workingDir,
+                projectPath = directory!!,
+            )
+            validateCreateAppTargetDirectory(target, overwrite)
         }
 
         if (!target.exists() && !target.mkdirs()) {
@@ -101,8 +113,8 @@ class CreateApp : CliktCommand("create-app") {
 
         cloneGradleProjectAndPrint(
             target = target,
-            packageName = packageName,
-            appName = appName,
+            packageName = resolvedPackageName,
+            appName = resolvedAppName,
             targets = targets,
             moduleName = "composeApp",
         )
@@ -213,91 +225,6 @@ class Init : CliktCommand("init") {
         )
     }
 
-    private fun readNamespace(): String {
-        while (true) {
-            echo("Enter package name (default: com.example.app): ", trailingNewline = false)
-            val namespace = readln().trim()
-            if (namespace.isEmpty()) {
-                return "com.example.app"
-            }
-
-            if (!isValidPackageName(namespace)) {
-                echo("Invalid package name. Must be a valid Java package name (e.g., com.example.app)")
-                continue
-            }
-
-            return namespace
-        }
-    }
-
-    private fun readAppName(): String {
-        while (true) {
-            echo("Enter app name (default: My App): ", trailingNewline = false)
-            val appName = readln().trim()
-
-            if (appName.isEmpty()) {
-                return "My App"
-            }
-
-            if (!isValidAppName(appName)) {
-                echo("Invalid app name. Must start with a letter and contain only letters, digits, or underscores")
-                continue
-            }
-
-            return appName
-        }
-    }
-
-    private fun readTargets(): Set<String> {
-        while (true) {
-            val targets = mutableSetOf<String>()
-
-            echo("Which platforms would you like your app to run on?")
-
-            while (true) {
-                echo("Android (y/n, default: y): ", trailingNewline = false)
-                val android = readln().trim().lowercase()
-                if (android.isEmpty() || android == "y" || android == "yes") {
-                    targets.add(ANDROID)
-                }
-                break
-            }
-
-            while (true) {
-                echo("JVM (Desktop) (y/n, default: y): ", trailingNewline = false)
-                val jvm = readln().trim().lowercase()
-                if (jvm.isEmpty() || jvm == "y" || jvm == "yes") {
-                    targets.add(JVM)
-                }
-                break
-            }
-
-            while (true) {
-                echo("iOS (y/n, default: y): ", trailingNewline = false)
-                val ios = readln().trim().lowercase()
-                if (ios.isEmpty() || ios == "y" || ios == "yes") {
-                    targets.add(IOS)
-                }
-                break
-            }
-
-            while (true) {
-                echo("Web (y/n, default: y): ", trailingNewline = false)
-                val web = readln().trim().lowercase()
-                if (web.isEmpty() || web == "y" || web == "yes") {
-                    targets.add(WEB)
-                }
-                break
-            }
-
-            if (targets.isNotEmpty()) {
-                return targets
-            } else {
-                echo("At least one platform is required...")
-            }
-        }
-    }
-
     private fun readModuleName(projectName: String): String {
         while (true) {
             echo("Enter module name (default: composeApp): ", trailingNewline = false)
@@ -360,6 +287,142 @@ internal fun resolveTargetDirectory(workingDir: String, projectPath: String): Fi
         requestedPath
     } else {
         File(workingDir).resolve(projectPath)
+    }
+}
+
+internal fun validateCreateAppTargetDirectory(target: File, overwrite: Boolean) {
+    when {
+        target.exists() && overwrite -> {
+            if (!target.deleteRecursively()) {
+                throw UsageError("Failed to overwrite existing directory at ${target.absolutePath}")
+            }
+        }
+
+        target.exists() && target.isFile -> {
+            throw UsageError("Target path ${target.absolutePath} is a file. Choose a different directory or use --overwrite.")
+        }
+
+        target.exists() && target.listFiles()?.isNotEmpty() == true -> {
+            throw UsageError("Target directory ${target.absolutePath} already exists and is not empty. Use --overwrite to replace it.")
+        }
+
+        target.exists() && target.listFiles()?.isEmpty() == true -> {
+            target.deleteRecursively()
+        }
+    }
+}
+
+internal fun readNewAppDirectory(workingDir: String): File {
+    while (true) {
+        print("Enter project directory: ")
+        val projectPath = readln().trim()
+        if (projectPath.isBlank()) {
+            println("Project directory is required.")
+            continue
+        }
+
+        val target = resolveTargetDirectory(workingDir = workingDir, projectPath = projectPath)
+        when {
+            target.exists() && target.isFile -> {
+                println("Target path ${target.absolutePath} is a file. Choose a different directory.")
+            }
+
+            target.exists() && target.listFiles()?.isNotEmpty() == true -> {
+                println("Target directory ${target.absolutePath} already exists and is not empty. Choose a different directory.")
+            }
+
+            else -> {
+                if (target.exists() && target.listFiles()?.isEmpty() == true) {
+                    target.deleteRecursively()
+                }
+                return target
+            }
+        }
+    }
+}
+
+internal fun readNamespace(): String {
+    while (true) {
+        print("Enter package name (default: com.example.app): ")
+        val namespace = readln().trim()
+        if (namespace.isEmpty()) {
+            return "com.example.app"
+        }
+
+        if (!isValidPackageName(namespace)) {
+            println("Invalid package name. Must be a valid Java package name (e.g., com.example.app)")
+            continue
+        }
+
+        return namespace
+    }
+}
+
+internal fun readAppName(): String {
+    while (true) {
+        print("Enter app name (default: My App): ")
+        val appName = readln().trim()
+
+        if (appName.isEmpty()) {
+            return "My App"
+        }
+
+        if (!isValidAppName(appName)) {
+            println("Invalid app name. Must contain at least one letter or digit")
+            continue
+        }
+
+        return appName
+    }
+}
+
+internal fun readTargets(): Set<String> {
+    while (true) {
+        val targets = mutableSetOf<String>()
+
+        println("Which platforms would you like your app to run on?")
+
+        while (true) {
+            print("Android (y/n, default: y): ")
+            val android = readln().trim().lowercase()
+            if (android.isEmpty() || android == "y" || android == "yes") {
+                targets.add(ANDROID)
+            }
+            break
+        }
+
+        while (true) {
+            print("JVM (Desktop) (y/n, default: y): ")
+            val jvm = readln().trim().lowercase()
+            if (jvm.isEmpty() || jvm == "y" || jvm == "yes") {
+                targets.add(JVM)
+            }
+            break
+        }
+
+        while (true) {
+            print("iOS (y/n, default: y): ")
+            val ios = readln().trim().lowercase()
+            if (ios.isEmpty() || ios == "y" || ios == "yes") {
+                targets.add(IOS)
+            }
+            break
+        }
+
+        while (true) {
+            print("Web (y/n, default: y): ")
+            val web = readln().trim().lowercase()
+            if (web.isEmpty() || web == "y" || web == "yes") {
+                targets.add(WEB)
+            }
+            break
+        }
+
+        if (targets.isNotEmpty()) {
+            return targets
+        } else {
+            println("At least one platform is required...")
+        }
     }
 }
 

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.isTrue
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class CliTest {
 
@@ -84,6 +85,22 @@ class CliTest {
 
         assertThat(targetDir.absolutePath).isEqualTo(projectPath)
         assertThat(targetDir.name).isEqualTo("sample-app")
+    }
+
+    @Test
+    fun `parseTargets normalizes and de-duplicates targets`() {
+        val targets = parseTargets("JVM, android, jvm, ios")
+
+        assertThat(targets).isEqualTo(linkedSetOf(JVM, ANDROID, IOS))
+    }
+
+    @Test
+    fun `parseTargets rejects unknown targets`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            parseTargets("android,desktop")
+        }
+
+        assertThat(error.message ?: "").contains("Unknown targets: desktop")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a dedicated \ command for non-interactive app creation
- keep \ for compatibility and existing module-oriented flows
- add tests for app creation, target parsing, and overwrite protection

## Verification
- ./gradlew :cli:spotlessApply :cli:spotlessCheck :cli:test --tests 'com.composables.cli.CliTest' :cli:integrationTest --tests 'com.composables.cli.CliIntegrationTest' --no-daemon