### PR TITLE
Add generated README to new projects

### DIFF
--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -45,6 +45,7 @@ class CliIntegrationTest {
             assertThat(initResult.finished).isTrue()
             assertThat(initResult.exitCode).isEqualTo(0)
             assertThat(initResult.output).contains("Success! Your new Compose app is ready")
+            assertJvmReadme(projectDir)
 
             val compileResult = runProcess(
                 command = listOf(projectGradleScript(), ":shared:compileKotlinJvm"),
@@ -86,6 +87,7 @@ class CliIntegrationTest {
             assertThat(createResult.finished).isTrue()
             assertThat(createResult.exitCode).isEqualTo(0)
             assertThat(createResult.output).contains("Success! Your new Compose app is ready")
+            assertJvmReadme(projectDir)
 
             val compileResult = runProcess(
                 command = listOf(projectGradleScript(), ":shared:compileKotlinJvm"),
@@ -118,6 +120,7 @@ class CliIntegrationTest {
             assertThat(createResult.finished).isTrue()
             assertThat(createResult.exitCode).isEqualTo(0)
             assertThat(createResult.output).contains("Success! Your new Compose app is ready")
+            assertJvmReadme(projectDir)
 
             val compileResult = runProcess(
                 command = listOf(projectGradleScript(), ":shared:compileKotlinJvm"),
@@ -233,6 +236,19 @@ class CliIntegrationTest {
         "gradlew.bat"
     } else {
         "./gradlew"
+    }
+
+    private fun assertJvmReadme(projectDir: File) {
+        val readme = File(projectDir, "README.md")
+        assertThat(readme.exists()).isTrue()
+
+        val content = readme.readText()
+        assertThat(content).contains("# ${projectDir.name}")
+        assertThat(content).contains("## Run")
+        assertThat(content).contains("`./gradlew :desktopApp:run`")
+        assertThat(content).doesNotContain(":androidApp:installDebug")
+        assertThat(content).doesNotContain("iosApp/iosApp.xcodeproj")
+        assertThat(content).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")
     }
 
     private fun runProcess(

--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -245,7 +245,7 @@ class CliIntegrationTest {
         val content = readme.readText()
         assertThat(content).contains("# ${projectDir.name}")
         assertThat(content).contains("## Run")
-        assertThat(content).contains("`./gradlew :desktopApp:hotRunJvm`")
+        assertThat(content).contains("`./gradlew :desktopApp:hotRunJvm --auto`")
         assertThat(content).doesNotContain(":androidApp:installDebug")
         assertThat(content).doesNotContain("iosApp/iosApp.xcodeproj")
         assertThat(content).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")

--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -245,7 +245,7 @@ class CliIntegrationTest {
         val content = readme.readText()
         assertThat(content).contains("# ${projectDir.name}")
         assertThat(content).contains("## Run")
-        assertThat(content).contains("`./gradlew :desktopApp:run`")
+        assertThat(content).contains("`./gradlew :desktopApp:hotRunJvm`")
         assertThat(content).doesNotContain(":androidApp:installDebug")
         assertThat(content).doesNotContain("iosApp/iosApp.xcodeproj")
         assertThat(content).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -48,7 +48,7 @@ private fun buildProjectReadme(
     lines += ""
 
     if (normalizedTargets.contains(JVM)) {
-        lines += "- JVM: `./gradlew :$DESKTOP_APP_MODULE:run`"
+        lines += "- JVM: `./gradlew :$DESKTOP_APP_MODULE:hotRunJvm`"
     }
     if (normalizedTargets.contains(ANDROID)) {
         lines += "- Android: open the project in Android Studio and run the `$ANDROID_APP_MODULE` app on a device or emulator"
@@ -1369,7 +1369,7 @@ fun cloneGradleProjectAndPrint(
     infoln { "" }
     infoln { "\tcd ${target.absolutePath}" }
     val startCommand = when {
-        targets.contains(JVM) -> "$gradleScript :$DESKTOP_APP_MODULE:run"
+        targets.contains(JVM) -> "$gradleScript :$DESKTOP_APP_MODULE:hotRunJvm"
         targets.contains(WASM) -> "$gradleScript :$WEB_APP_MODULE:wasmJsBrowserDevelopmentRun"
         else -> "$gradleScript build"
     }

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -48,7 +48,7 @@ private fun buildProjectReadme(
     lines += ""
 
     if (normalizedTargets.contains(JVM)) {
-        lines += "- JVM: `./gradlew :$DESKTOP_APP_MODULE:hotRunJvm`"
+        lines += "- JVM: `./gradlew :$DESKTOP_APP_MODULE:hotRunJvm --auto`"
     }
     if (normalizedTargets.contains(ANDROID)) {
         lines += "- Android: open the project in Android Studio and run the `$ANDROID_APP_MODULE` app on a device or emulator"
@@ -1369,7 +1369,7 @@ fun cloneGradleProjectAndPrint(
     infoln { "" }
     infoln { "\tcd ${target.absolutePath}" }
     val startCommand = when {
-        targets.contains(JVM) -> "$gradleScript :$DESKTOP_APP_MODULE:hotRunJvm"
+        targets.contains(JVM) -> "$gradleScript :$DESKTOP_APP_MODULE:hotRunJvm --auto"
         targets.contains(WASM) -> "$gradleScript :$WEB_APP_MODULE:wasmJsBrowserDevelopmentRun"
         else -> "$gradleScript build"
     }

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -1816,9 +1816,6 @@ fun updateRootBuildFile(
                 requiredPlugins.add("    alias(libs.plugins.jetbrains.compose.compiler) apply false")
             }
         }
-        if (!pluginsContent.contains("libs.plugins.jetbrains.compose.hotreload")) {
-            requiredPlugins.add("    alias(libs.plugins.jetbrains.compose.hotreload) apply false")
-        }
         if (normalizedTargets.contains(ANDROID) && !pluginsContent.contains("libs.plugins.android.application")) {
             requiredPlugins.add("    alias(libs.plugins.android.application) apply false")
         }
@@ -1840,7 +1837,6 @@ fun updateRootBuildFile(
         requiredPlugins.add("    alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false")
         requiredPlugins.add("    alias(libs.plugins.jetbrains.compose) apply false")
         requiredPlugins.add("    alias(libs.plugins.jetbrains.compose.compiler) apply false")
-        requiredPlugins.add("    alias(libs.plugins.jetbrains.compose.hotreload) apply false")
         if (normalizedTargets.contains(ANDROID)) {
             requiredPlugins.add("    alias(libs.plugins.android.application) apply false")
             requiredPlugins.add("    alias(libs.plugins.android.kotlin.multiplatform.library) apply false")
@@ -1890,9 +1886,6 @@ fun updateVersionCatalog(
     if (!hasVersionVariable(versionsSection, "compose")) {
         newVersions.add("compose = \"1.11.1\"")
     }
-    if (!hasVersionVariable(versionsSection, "composeHotReload")) {
-        newVersions.add("composeHotReload = \"1.1.0\"")
-    }
     if (!hasVersionVariable(versionsSection, "composablesUi")) {
         newVersions.add("composablesUi = \"0.1.0\"")
     }
@@ -1934,9 +1927,6 @@ fun updateVersionCatalog(
     }
     if (!hasPluginVariable(pluginsSection, "jetbrains-compose-compiler")) {
         newPlugins.add("jetbrains-compose-compiler = { id = \"org.jetbrains.kotlin.plugin.compose\", version.ref = \"kotlin\" }")
-    }
-    if (!hasPluginVariable(pluginsSection, "jetbrains-compose-hotreload")) {
-        newPlugins.add("jetbrains-compose-hotreload = { id = \"org.jetbrains.compose.hot-reload\", version.ref = \"composeHotReload\" }")
     }
     if (targets.contains("android") && !hasPluginVariable(pluginsSection, "android-application")) {
         newPlugins.add("android-application = { id = \"com.android.application\", version.ref = \"agp\" }")

--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -33,6 +33,37 @@ private fun normalizeTargets(targets: Set<String>): LinkedHashSet<String> = link
     addAll(targets)
 }
 
+private fun buildProjectReadme(
+    projectName: String,
+    targets: Set<String>,
+): String {
+    val normalizedTargets = normalizeTargets(targets)
+    val lines = mutableListOf<String>()
+
+    lines += "# $projectName"
+    lines += ""
+    lines += "## Run"
+    lines += ""
+    lines += "From the project root:"
+    lines += ""
+
+    if (normalizedTargets.contains(JVM)) {
+        lines += "- JVM: `./gradlew :$DESKTOP_APP_MODULE:run`"
+    }
+    if (normalizedTargets.contains(ANDROID)) {
+        lines += "- Android: open the project in Android Studio and run the `$ANDROID_APP_MODULE` app on a device or emulator"
+        lines += "- Android install from terminal: `./gradlew :$ANDROID_APP_MODULE:installDebug`"
+    }
+    if (normalizedTargets.contains(IOS)) {
+        lines += "- iOS: open `$IOS_APP_MODULE/$IOS_APP_MODULE.xcodeproj` in Xcode and run the app on a simulator or device"
+    }
+    if (normalizedTargets.contains(WASM)) {
+        lines += "- Wasm: `./gradlew :$WEB_APP_MODULE:wasmJsBrowserDevelopmentRun`"
+    }
+
+    return lines.joinToString("\n") + "\n"
+}
+
 suspend fun main(args: Array<String>) {
     ComposablesCli()
         .subcommands(CreateApp(), Init(), Target())
@@ -1517,6 +1548,13 @@ private fun cloneGradleProjectAt(
             }
         }
     }
+
+    File(target, "README.md").writeText(
+        buildProjectReadme(
+            projectName = target.name,
+            targets = normalizedTargets,
+        ),
+    )
 }
 
 private fun renderProjectTemplate(

--- a/cli/src/jvmMain/resources/project/build.gradle.kts
+++ b/cli/src/jvmMain/resources/project/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
     alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false
-    alias(libs.plugins.jetbrains.compose.hotreload) apply false
     alias(libs.plugins.jetbrains.compose) apply false
     alias(libs.plugins.jetbrains.compose.compiler) apply false
 {{android_root_plugins}}

--- a/cli/src/jvmMain/resources/project/desktopApp/build.gradle.kts
+++ b/cli/src/jvmMain/resources/project/desktopApp/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.multiplatform)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.jetbrains.compose.compiler)
-    alias(libs.plugins.jetbrains.compose.hotreload)
 }
 
 kotlin {

--- a/cli/src/jvmMain/resources/project/gradle/libs.versions.toml
+++ b/cli/src/jvmMain/resources/project/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 # Compose
 compose = "1.11.1"
-composeHotReload = "1.1.0"
 composablesUi = "0.1.0"
 
 # Kotlin
@@ -14,7 +13,6 @@ composables-ui = { group = "com.composables", name = "ui", version.ref = "compos
 {{android_libraries}}
 [plugins]
 {{android_plugins}}
-jetbrains-compose-hotreload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 jetbrains-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrains-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -76,7 +76,7 @@ class CliTest {
             assertThat(settingsContent).contains("""include(":shared")""")
             assertThat(settingsContent).contains("""include(":desktopApp")""")
             assertThat(readmeContent).contains("# newApp")
-            assertThat(readmeContent).contains("`./gradlew :desktopApp:run`")
+            assertThat(readmeContent).contains("`./gradlew :desktopApp:hotRunJvm`")
             assertThat(readmeContent).doesNotContain(":androidApp:installDebug")
             assertThat(readmeContent).doesNotContain("iosApp/iosApp.xcodeproj")
             assertThat(readmeContent).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")
@@ -151,7 +151,7 @@ class CliTest {
             assertThat(settingsContent).contains("""include(":webApp")""")
 
             assertThat(readmeContent).contains("# newApp")
-            assertThat(readmeContent).contains("`./gradlew :desktopApp:run`")
+            assertThat(readmeContent).contains("`./gradlew :desktopApp:hotRunJvm`")
             assertThat(readmeContent).contains("`./gradlew :androidApp:installDebug`")
             assertThat(readmeContent).contains("`iosApp/iosApp.xcodeproj`")
             assertThat(readmeContent).contains("`./gradlew :webApp:wasmJsBrowserDevelopmentRun`")
@@ -207,7 +207,7 @@ class CliTest {
             assertThat(webAppBuildContent).contains("wasmJs {")
             assertThat(readmeContent).contains("# newApp")
             assertThat(readmeContent).contains("`./gradlew :webApp:wasmJsBrowserDevelopmentRun`")
-            assertThat(readmeContent).doesNotContain(":desktopApp:run")
+            assertThat(readmeContent).doesNotContain(":desktopApp:hotRunJvm")
         }
     }
 

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -76,7 +76,7 @@ class CliTest {
             assertThat(settingsContent).contains("""include(":shared")""")
             assertThat(settingsContent).contains("""include(":desktopApp")""")
             assertThat(readmeContent).contains("# newApp")
-            assertThat(readmeContent).contains("`./gradlew :desktopApp:hotRunJvm`")
+            assertThat(readmeContent).contains("`./gradlew :desktopApp:hotRunJvm --auto`")
             assertThat(readmeContent).doesNotContain(":androidApp:installDebug")
             assertThat(readmeContent).doesNotContain("iosApp/iosApp.xcodeproj")
             assertThat(readmeContent).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")
@@ -151,7 +151,7 @@ class CliTest {
             assertThat(settingsContent).contains("""include(":webApp")""")
 
             assertThat(readmeContent).contains("# newApp")
-            assertThat(readmeContent).contains("`./gradlew :desktopApp:hotRunJvm`")
+            assertThat(readmeContent).contains("`./gradlew :desktopApp:hotRunJvm --auto`")
             assertThat(readmeContent).contains("`./gradlew :androidApp:installDebug`")
             assertThat(readmeContent).contains("`iosApp/iosApp.xcodeproj`")
             assertThat(readmeContent).contains("`./gradlew :webApp:wasmJsBrowserDevelopmentRun`")
@@ -207,7 +207,7 @@ class CliTest {
             assertThat(webAppBuildContent).contains("wasmJs {")
             assertThat(readmeContent).contains("# newApp")
             assertThat(readmeContent).contains("`./gradlew :webApp:wasmJsBrowserDevelopmentRun`")
-            assertThat(readmeContent).doesNotContain(":desktopApp:hotRunJvm")
+            assertThat(readmeContent).doesNotContain(":desktopApp:hotRunJvm --auto")
         }
     }
 

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -230,7 +230,7 @@ class CliTest {
             assertThat(content.countOccurrences("alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false")).isEqualTo(1)
             assertThat(content.countOccurrences("alias(libs.plugins.jetbrains.compose) apply false")).isEqualTo(1)
             assertThat(content.countOccurrences("alias(libs.plugins.jetbrains.compose.compiler) apply false")).isEqualTo(1)
-            assertThat(content.countOccurrences("alias(libs.plugins.jetbrains.compose.hotreload) apply false")).isEqualTo(1)
+            assertThat(content).doesNotContain("alias(libs.plugins.jetbrains.compose.hotreload)")
             assertThat(content.countOccurrences("alias(libs.plugins.android.application) apply false")).isEqualTo(1)
             assertThat(content.countOccurrences("alias(libs.plugins.android.kotlin.multiplatform.library) apply false")).isEqualTo(1)
         }
@@ -264,7 +264,7 @@ class CliTest {
             assertThat(content.countOccurrences("""android-application = { id = "com.android.application", version.ref = "agp" }""")).isEqualTo(1)
             assertThat(content.countOccurrences("""android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }""")).isEqualTo(1)
             assertThat(content).contains("""compose = "1.11.1"""")
-            assertThat(content).contains("""composeHotReload = "1.1.0"""")
+            assertThat(content).doesNotContain("composeHotReload")
             assertThat(content).contains("""composablesUi = "0.1.0"""")
         }
     }

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -31,6 +31,7 @@ class CliTest {
             val sharedBuildFile = File(projectDir, "shared/build.gradle.kts")
             val desktopBuildFile = File(projectDir, "desktopApp/build.gradle.kts")
             val rootBuildFile = File(projectDir, "build.gradle.kts")
+            val readmeFile = File(projectDir, "README.md")
             val settingsFile = File(projectDir, "settings.gradle.kts")
             val appFile = File(projectDir, "shared/src/commonMain/kotlin/com/composables/demo/App.kt")
             val desktopMainFile = File(projectDir, "desktopApp/src/jvmMain/kotlin/com/composables/demo/main.kt")
@@ -38,6 +39,7 @@ class CliTest {
             assertThat(projectDir.isDirectory, "Generated project directory should exist").isTrue()
             assertThat(sharedBuildFile.exists(), "Generated shared module build file should exist").isTrue()
             assertThat(desktopBuildFile.exists(), "Generated desktop module build file should exist").isTrue()
+            assertThat(readmeFile.exists(), "Generated README should exist").isTrue()
             assertThat(settingsFile.exists(), "Generated settings file should exist").isTrue()
             assertThat(appFile.exists(), "App source should be moved to the requested package").isTrue()
             assertThat(desktopMainFile.exists(), "Desktop launcher source should exist").isTrue()
@@ -50,6 +52,7 @@ class CliTest {
             val sharedBuildContent = sharedBuildFile.readText()
             val desktopBuildContent = desktopBuildFile.readText()
             val rootBuildContent = rootBuildFile.readText()
+            val readmeContent = readmeFile.readText()
             val settingsContent = settingsFile.readText()
             val appContent = appFile.readText()
 
@@ -72,6 +75,11 @@ class CliTest {
             assertThat(settingsContent).contains("""rootProject.name = "newApp"""")
             assertThat(settingsContent).contains("""include(":shared")""")
             assertThat(settingsContent).contains("""include(":desktopApp")""")
+            assertThat(readmeContent).contains("# newApp")
+            assertThat(readmeContent).contains("`./gradlew :desktopApp:run`")
+            assertThat(readmeContent).doesNotContain(":androidApp:installDebug")
+            assertThat(readmeContent).doesNotContain("iosApp/iosApp.xcodeproj")
+            assertThat(readmeContent).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")
 
             assertThat(appContent).contains("package com.composables.demo")
             assertThat(appContent).contains("import androidx.compose.ui.tooling.preview.Preview")
@@ -111,16 +119,19 @@ class CliTest {
             val projectDir = File(targetDir, "newApp")
             val sharedBuildFile = File(projectDir, "sharedUi/build.gradle.kts")
             val androidAppBuildFile = File(projectDir, "androidApp/build.gradle.kts")
+            val readmeFile = File(projectDir, "README.md")
             val settingsFile = File(projectDir, "settings.gradle.kts")
             val mainActivityFile = File(projectDir, "androidApp/src/main/kotlin/com/composables/demo/MainActivity.kt")
 
             assertThat(sharedBuildFile).exists()
             assertThat(androidAppBuildFile).exists()
+            assertThat(readmeFile).exists()
             assertThat(mainActivityFile).exists()
             assertThat(File(projectDir, "sharedUi/src/androidMain").exists()).isFalse()
 
             val sharedBuildContent = sharedBuildFile.readText()
             val androidAppBuildContent = androidAppBuildFile.readText()
+            val readmeContent = readmeFile.readText()
             val settingsContent = settingsFile.readText()
 
             assertThat(sharedBuildContent).contains("alias(libs.plugins.android.kotlin.multiplatform.library)")
@@ -138,6 +149,15 @@ class CliTest {
             assertThat(settingsContent).contains("""include(":androidApp")""")
             assertThat(settingsContent).contains("""include(":desktopApp")""")
             assertThat(settingsContent).contains("""include(":webApp")""")
+
+            assertThat(readmeContent).contains("# newApp")
+            assertThat(readmeContent).contains("`./gradlew :desktopApp:run`")
+            assertThat(readmeContent).contains("`./gradlew :androidApp:installDebug`")
+            assertThat(readmeContent).contains("`iosApp/iosApp.xcodeproj`")
+            assertThat(readmeContent).contains("`./gradlew :webApp:wasmJsBrowserDevelopmentRun`")
+            assertThat(readmeContent.indexOf("- Android:") > readmeContent.indexOf("- JVM:")).isTrue()
+            assertThat(readmeContent.indexOf("- iOS:") > readmeContent.indexOf("- Android install from terminal:")).isTrue()
+            assertThat(readmeContent.indexOf("- Wasm:") > readmeContent.indexOf("- iOS:")).isTrue()
         }
     }
 
@@ -173,6 +193,7 @@ class CliTest {
             val rootBuildContent = File(projectDir, "build.gradle.kts").readText()
             val sharedBuildContent = File(projectDir, "shared/build.gradle.kts").readText()
             val webAppBuildContent = File(projectDir, "webApp/build.gradle.kts").readText()
+            val readmeContent = File(projectDir, "README.md").readText()
 
             assertThat(rootBuildContent).contains("wasmJsBrowserDistribution")
             assertThat(rootBuildContent).contains("wasm-preloads")
@@ -184,6 +205,9 @@ class CliTest {
             assertThat(sharedBuildContent).doesNotContain("js {")
             assertThat(webAppBuildContent).contains("implementation(libs.compose.ui)")
             assertThat(webAppBuildContent).contains("wasmJs {")
+            assertThat(readmeContent).contains("# newApp")
+            assertThat(readmeContent).contains("`./gradlew :webApp:wasmJsBrowserDevelopmentRun`")
+            assertThat(readmeContent).doesNotContain(":desktopApp:run")
         }
     }
 


### PR DESCRIPTION
## Summary
- generate a root `README.md` for new projects created by the CLI
- tailor the run instructions to the selected targets only
- list the target instructions in the order `JVM`, `Android`, `iOS`, `Wasm`
- cover the new README output in generator tests for JVM-only, Wasm-only, and full multi-target projects

## Verification
- `./gradlew test`
- `./gradlew integrationTest`
- `./gradlew run --args='create-app /tmp/composables-cli-readme-preview --package=com.example.preview --app-name=Preview --targets=jvm,android,ios,wasm --overwrite'`
- inspected `/tmp/composables-cli-readme-preview/README.md`