### PR TITLE
Remove legacy Android target detection

### DIFF
--- a/cli/src/jvmMain/kotlin/Cli.kt
+++ b/cli/src/jvmMain/kotlin/Cli.kt
@@ -715,7 +715,7 @@ class Target : CliktCommand("target") {
 
     private fun hasAndroidTarget(buildFile: File): Boolean {
         val content = buildFile.readText()
-        return content.contains("androidLibrary {") || content.contains("androidTarget {") || content.contains("android {")
+        return content.contains("android {")
     }
 
     private fun hasJvmTarget(buildFile: File): Boolean {

--- a/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
+++ b/cli/src/jvmTest/kotlin/com/composables/cli/CliTest.kt
@@ -270,6 +270,54 @@ class CliTest {
     }
 
     @Test
+    fun `target command detects current android target shape`() {
+        withTempDir { targetDir ->
+            val buildFile = File(targetDir, "build.gradle.kts").apply {
+                writeText(
+                    """
+                    kotlin {
+                        android {
+                            namespace = "com.example.shared"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+            assertThat(hasAndroidTarget(buildFile)).isTrue()
+        }
+    }
+
+    @Test
+    fun `target command ignores legacy android target shapes`() {
+        withTempDir { targetDir ->
+            val androidTargetFile = File(targetDir, "android-target.gradle.kts").apply {
+                writeText(
+                    """
+                    kotlin {
+                        androidTarget()
+                    }
+                    """.trimIndent(),
+                )
+            }
+            val androidLibraryFile = File(targetDir, "android-library.gradle.kts").apply {
+                writeText(
+                    """
+                    kotlin {
+                        androidLibrary {
+                            namespace = "com.example.shared"
+                        }
+                    }
+                    """.trimIndent(),
+                )
+            }
+
+            assertThat(hasAndroidTarget(androidTargetFile)).isFalse()
+            assertThat(hasAndroidTarget(androidLibraryFile)).isFalse()
+        }
+    }
+
+    @Test
     fun `gradleScript uses batch file on windows`() {
         withOsName("Windows 11") {
             assertThat(gradleScript).isEqualTo("gradlew.bat")
@@ -300,6 +348,12 @@ class CliTest {
         } finally {
             System.setProperty("os.name", original)
         }
+    }
+
+    private fun hasAndroidTarget(buildFile: File): Boolean {
+        val method = Target::class.java.getDeclaredMethod("hasAndroidTarget", File::class.java)
+        method.isAccessible = true
+        return method.invoke(Target(), buildFile) as Boolean
     }
 
     private fun String.countOccurrences(value: String): Int = split(value).size - 1


### PR DESCRIPTION
## Summary
- remove stale Android target detection branches for old generated project shapes
- keep Android target detection aligned with the current supported `android {}` DSL
- add tests covering current Android detection and explicit non-support for legacy shapes

## Verification
- `./gradlew :cli:test --tests com.composables.cli.CliTest`
- `./gradlew test`
- `./gradlew spotlessCheck`