### PR TITLE
Verify generated desktop hot reload task

### DIFF
--- a/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
+++ b/cli/src/integrationTest/kotlin/com/composables/cli/CliIntegrationTest.kt
@@ -249,6 +249,19 @@ class CliIntegrationTest {
         assertThat(content).doesNotContain(":androidApp:installDebug")
         assertThat(content).doesNotContain("iosApp/iosApp.xcodeproj")
         assertThat(content).doesNotContain(":webApp:wasmJsBrowserDevelopmentRun")
+
+        val hotRunHelp = runProcess(
+            command = listOf(projectGradleScript(), "help", "--task", ":desktopApp:hotRunJvm"),
+            workingDir = projectDir,
+            timeoutSeconds = 180,
+        )
+
+        assertThat(hotRunHelp.finished).isTrue()
+        assertThat(hotRunHelp.exitCode).isEqualTo(0)
+        assertThat(hotRunHelp.output).contains("Path")
+        assertThat(hotRunHelp.output).contains(":desktopApp:hotRunJvm")
+        assertThat(hotRunHelp.output).contains("--auto")
+        assertThat(hotRunHelp.output).contains("Enables automatic recompilation/reload once the source files change")
     }
 
     private fun runProcess(


### PR DESCRIPTION
## Summary
- keep the generated README assertion for `:desktopApp:hotRunJvm --auto`
- add a generated-project Gradle help check for `:desktopApp:hotRunJvm`
- verify the generated desktop project exposes the documented `--auto` hot reload flag

## Why
The existing tests proved that the README mentioned the hot reload command, but not that generated desktop projects actually exposed that task and option. This adds explicit confidence in the documented `hotRunJvm --auto` workflow without introducing flaky runtime automation.

## Verification
- `./gradlew :cli:integrationTest --tests com.composables.cli.CliIntegrationTest spotlessCheck`